### PR TITLE
[FEAT] Store 페이지 Molecule 레벨의 컴포넌트 구현

### DIFF
--- a/src/components/atoms/cardIcon/CardIcon.tsx
+++ b/src/components/atoms/cardIcon/CardIcon.tsx
@@ -5,18 +5,31 @@ export interface CardIconProps {
   isOn: boolean;
 }
 
-function CardIcon({ category, isOn }: CardIconProps) {
-  const getIconPath = () => {
-    const iconMap = {
-      spanner: isOn ? '/icons/FixBlue.svg' : '/icons/Fix.svg',
-      home: isOn ? '/icons/HomeBlue.svg' : '/icons/Home.svg',
-      pallete: isOn ? '/icons/PalleteBlue.svg' : '/icons/Pallete.svg',
-      pencil: isOn ? '/icons/PencilBlue.svg' : '/icons/Pencil.svg',
-      women: isOn ? '/icons/WomenBlue.svg' : '/icons/Women.svg',
-    };
+const ICON_PATHS = {
+  spanner: {
+    on: '/icons/FixBlue.svg',
+    off: '/icons/Fix.svg',
+  },
+  home: {
+    on: '/icons/HomeBlue.svg',
+    off: '/icons/Home.svg',
+  },
+  pallete: {
+    on: '/icons/PalleteBlue.svg',
+    off: '/icons/Pallete.svg',
+  },
+  pencil: {
+    on: '/icons/PencilBlue.svg',
+    off: '/icons/Pencil.svg',
+  },
+  women: {
+    on: '/icons/WomenBlue.svg',
+    off: '/icons/Women.svg',
+  },
+} as const;
 
-    return iconMap[category];
-  };
+function CardIcon({ category, isOn }: CardIconProps) {
+  const iconPath = ICON_PATHS[category][isOn ? 'on' : 'off'];
 
   return (
     <div
@@ -24,7 +37,7 @@ function CardIcon({ category, isOn }: CardIconProps) {
         isOn ? 'bg-primary1' : 'bg-black3'
       }`}
     >
-      <Image src={getIconPath()} alt={category} width={24} height={24} />
+      <Image src={iconPath} alt={category} width={24} height={24} />
     </div>
   );
 }

--- a/src/components/atoms/progressBar/ProgressBar.stories.tsx
+++ b/src/components/atoms/progressBar/ProgressBar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import ProgressBar from './ProgressBar';
+import ProgressBar, { ProgressStep } from './ProgressBar';
 
 const meta: Meta<typeof ProgressBar> = {
   title: 'Atoms/ProgressBar',
@@ -22,30 +22,30 @@ type Story = StoryObj<typeof ProgressBar>;
 
 export const Default: Story = {
   args: {
-    progress: 'default',
+    step: ProgressStep.STEP1,
   },
 };
 
 export const Quarter: Story = {
   args: {
-    progress: 'quarter',
+    step: ProgressStep.STEP2,
   },
 };
 
 export const Half: Story = {
   args: {
-    progress: 'half',
+    step: ProgressStep.STEP3,
   },
 };
 
 export const ThreeQuarters: Story = {
   args: {
-    progress: 'three-quarters',
+    step: ProgressStep.STEP4,
   },
 };
 
 export const Done: Story = {
   args: {
-    progress: 'done',
+    step: ProgressStep.STEP5,
   },
 };

--- a/src/components/atoms/progressBar/ProgressBar.tsx
+++ b/src/components/atoms/progressBar/ProgressBar.tsx
@@ -1,25 +1,28 @@
-interface ProgressBarProps {
-  progress: 'default' | 'quarter' | 'half' | 'three-quarters' | 'done';
+export enum ProgressStep {
+  STEP1 = 1,
+  STEP2 = 2,
+  STEP3 = 3,
+  STEP4 = 4,
+  STEP5 = 5,
 }
 
-function ProgressBar({ progress }: ProgressBarProps) {
-  const getProgressWidth = () => {
-    const progressMap = {
-      default: '15%',
-      quarter: '25%',
-      half: '50%',
-      'three-quarters': '75%',
-      done: '100%',
-    };
+const PROGRESS_STYLES: Record<ProgressStep, string> = {
+  [ProgressStep.STEP1]: 'w-[15%] bg-primary5',
+  [ProgressStep.STEP2]: 'w-1/4 bg-primary5',
+  [ProgressStep.STEP3]: 'w-1/2 bg-primary5',
+  [ProgressStep.STEP4]: 'w-3/4 bg-primary5',
+  [ProgressStep.STEP5]: 'w-full bg-primary5',
+} as const;
 
-    return progressMap[progress];
-  };
+interface ProgressBarProps {
+  step: ProgressStep;
+}
 
+function ProgressBar({ step }: ProgressBarProps) {
   return (
     <div className="w-full h-15 bg-black2 rounded-full overflow-hidden">
       <div
-        className="h-full bg-primary5 rounded-full transition-all duration-300 ease-in-out"
-        style={{ width: getProgressWidth() }}
+        className={`h-full rounded-full transition-all duration-300 ease-in-out ${PROGRESS_STYLES[step]}`}
       />
     </div>
   );

--- a/src/components/atoms/selectedOption/SelectedOption.tsx
+++ b/src/components/atoms/selectedOption/SelectedOption.tsx
@@ -1,38 +1,42 @@
+type OptionType = 'left-impact' | 'right-impact' | 'price-small' | 'price-large';
+
+interface StyleConfig {
+  container: string;
+  left: string;
+  right: string;
+}
+
 interface SelectedOptionProps {
-  type: 'left-impact' | 'right-impact' | 'price-small' | 'price-large';
+  type: OptionType;
   leftText: string;
   rightText: string;
 }
 
+const OPTION_STYLES: Record<OptionType, StyleConfig> = {
+  'left-impact': {
+    container: 'gap-12',
+    left: 'text-16 text-black12 font-semibold',
+    right: 'text-16 text-black7 font-medium',
+  },
+  'right-impact': {
+    container: 'gap-12',
+    left: 'text-16 text-black7 font-medium',
+    right: 'text-16 text-black12 font-semibold',
+  },
+  'price-small': {
+    container: '',
+    left: 'text-16 text-black7 font-medium',
+    right: 'text-16 text-black7 font-semibold',
+  },
+  'price-large': {
+    container: '',
+    left: 'text-20 text-black10 font-medium',
+    right: 'text-20 text-black12 font-semibold',
+  },
+} as const;
+
 function SelectedOption({ type, leftText, rightText }: SelectedOptionProps) {
-  const getStyles = () => {
-    const styleMap = {
-      'left-impact': {
-        container: 'gap-12',
-        left: 'text-16 text-black12 font-semibold',
-        right: 'text-16 text-black7 font-medium',
-      },
-      'right-impact': {
-        container: 'gap-12',
-        left: 'text-16 text-black7 font-medium',
-        right: 'text-16 text-black12 font-semibold',
-      },
-      'price-small': {
-        container: '',
-        left: 'text-16 text-black7 font-medium',
-        right: 'text-16 text-black7 font-semibold',
-      },
-      'price-large': {
-        container: '',
-        left: 'text-20 text-black10 font-medium',
-        right: 'text-20 text-black12 font-semibold',
-      },
-    };
-
-    return styleMap[type];
-  };
-
-  const styles = getStyles();
+  const styles = OPTION_STYLES[type];
 
   return (
     <div className={`w-full flex items-center justify-between ${styles.container}`}>

--- a/src/components/molecules/comissionListItem/ComissionListItem.tsx
+++ b/src/components/molecules/comissionListItem/ComissionListItem.tsx
@@ -21,7 +21,7 @@ function ComissionListItem({
   created_at,
 }: ComissionListItemProps) {
   return (
-    <article className="w-953 flex justify-between gap-44 px-44 py-40 rounded-2xl hover:shadow-hover transition-all duration-300">
+    <article className="w-953 flex justify-between gap-44 px-44 py-40 rounded-2xl hover:shadow-project-item-card transition-all duration-300">
       <div className="flex flex-col gap-40">
         <div className="flex flex-col gap-24">
           <div className="flex gap-8 items-center">

--- a/src/components/molecules/productListItem/ProductListItem.stories.tsx
+++ b/src/components/molecules/productListItem/ProductListItem.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ProductListItem from './ProductListItem';
+
+const meta = {
+  title: 'Molecules/ProductListItem',
+  component: ProductListItem,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ProductListItem>;
+
+export default meta;
+type Story = StoryObj<typeof ProductListItem>;
+
+const baseArgs = {
+  imageUrl:
+    'https://t4.ftcdn.net/jpg/02/70/95/21/360_F_270952103_2zSDVMWHM7KFOXmO0Dko0pYOE9aCs07k.jpg',
+  category: '디지털 컨텐츠' as const,
+  title: '디테일이 살아있는 차트 UI',
+  seller_name: '코딩천재',
+  price: 35000,
+};
+
+export const Large: Story = {
+  args: {
+    ...baseArgs,
+    size: 'large',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    ...baseArgs,
+    size: 'small',
+  },
+};
+
+export const LivingCategory: Story = {
+  args: {
+    ...baseArgs,
+    size: 'large',
+    category: '리빙' as const,
+    title: '수제 도자기 그릇 세트',
+    seller_name: '도예공방',
+    price: 89000,
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    ...baseArgs,
+    size: 'large',
+    title: '2024년 최신 트렌드가 반영된 웹디자인 템플릿 모음집 한정판',
+  },
+};
+
+export const NoImage: Story = {
+  args: {
+    ...baseArgs,
+    size: 'large',
+    imageUrl: '',
+  },
+};
+
+export const HighPrice: Story = {
+  args: {
+    ...baseArgs,
+    size: 'large',
+    price: 1250000,
+  },
+};

--- a/src/components/molecules/productListItem/ProductListItem.tsx
+++ b/src/components/molecules/productListItem/ProductListItem.tsx
@@ -1,0 +1,65 @@
+import Image from 'next/image';
+import NumberReadability from '@/components/atoms/numberReadability/NumberReadability';
+import SmallTag from '@/components/atoms/smallTag/SmallTag';
+
+interface ProductListItemProps {
+  size: 'small' | 'large';
+  imageUrl: string;
+  category: '디지털 컨텐츠' | '리빙';
+  title: string;
+  seller_name: string;
+  price: number;
+}
+
+const SIZE_CONFIG = {
+  small: {
+    container: 'w-193',
+    imageStlye: 'w-193 h-193',
+    imageSize: 193,
+  },
+  large: {
+    container: 'w-302',
+    imageStlye: 'w-302 h-302',
+    imageSize: 302,
+  },
+} as const;
+
+function ProductListItem({
+  size,
+  imageUrl,
+  category,
+  title,
+  seller_name,
+  price,
+}: ProductListItemProps) {
+  const sizeStyle = SIZE_CONFIG[size];
+
+  return (
+    <div className={`${sizeStyle.container} flex flex-col gap-16 group`}>
+      <div className={`${sizeStyle.imageStlye} rounded-2xl overflow-hidden`}>
+        <Image
+          src={imageUrl || 'https://placehold.co/302x302?text=DOPDANG'}
+          alt={title}
+          width={sizeStyle.imageSize}
+          height={sizeStyle.imageSize}
+          className="size-full object-cover group-hover:scale-105 transition-all duration-300 "
+        />
+      </div>
+
+      <div className="flex flex-col gap-8">
+        <div className="flex gap-8">
+          <SmallTag text={category} theme={category === '리빙' ? 'lightOrange' : 'lightBlue'} />
+          <SmallTag text="소분류" theme="gray" />
+        </div>
+        <span className="text-16 font-regular text-black12 truncate">{title}</span>
+        <span className="text-13 font-regular text-black7">{seller_name}</span>
+      </div>
+
+      <div className="flex text-20 font-bold text-black12">
+        <NumberReadability value={price} />원
+      </div>
+    </div>
+  );
+}
+
+export default ProductListItem;


### PR DESCRIPTION
## 📌 PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서

## ✅ 반영 브랜치

- [ ] main
- [x] merge

## 🔥 변경사항
- Molecule 레벨의 ProductListItem 컴포넌트를 구현하였습니다.
- 기존에 작성한 Atom 레벨 컴포넌트 CardIcon, ProgressBar, SelectedOption의 구조를 리팩토링 하였습니다.
(함수 호출 대신 상수 객체를 사용하는 방식으로 리팩토링하여 확장성 높이기)
- ComissionListItem컴포넌트의 hover 그림자 클래스명 변경 (`shadow-hover` -> `shadow-project-item-card`)

## 📸 참고 사진
![image](https://github.com/user-attachments/assets/5cf6bcab-a909-41ad-be24-53925d4de7f4)



