### PR TITLE
[FEAT] 마이페이지 내 정보 페이지 비밀번호 수정 기능 구현

### DIFF
--- a/src/apis/user/updatePassword.ts
+++ b/src/apis/user/updatePassword.ts
@@ -1,0 +1,52 @@
+import { APIBuilder } from '@/utils/APIBuilder';
+import { ApiError } from '@/types/api';
+
+export interface UpdatePasswordRequest {
+  userId: number;
+  currentPassword: string;
+  newPassword: string;
+}
+
+export interface UpdatePasswordResponse {
+  message: string;
+}
+
+export interface PasswordError {
+  code: number;
+  message: string;
+}
+
+export const updatePassword = async (
+  request: UpdatePasswordRequest,
+): Promise<UpdatePasswordResponse> => {
+  const { userId, currentPassword, newPassword } = request;
+
+  try {
+    const response = await APIBuilder.patch(`/users/password/${userId}`, {
+      currentPassword,
+      newPassword,
+    })
+      .timeout(10000)
+      .build()
+      .call<UpdatePasswordResponse>();
+
+    return response.data;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      // API 에러 정보 추출
+      const status = error.status || 500;
+      const message = error.message || '알 수 없는 오류가 발생했습니다.';
+
+      throw {
+        code: status,
+        message: message,
+      } as PasswordError;
+    }
+
+    // 기타 예외 처리
+    throw {
+      code: 500,
+      message: '서버 내부 오류가 발생했습니다.',
+    } as PasswordError;
+  }
+};

--- a/src/app/myPage/layout.tsx
+++ b/src/app/myPage/layout.tsx
@@ -1,90 +1,15 @@
-'use client';
-
 import '../globals.css';
 import ReactQueryClientProvider from '@/config/ReactQueryClientProvider';
-import { useRouter } from 'next/navigation';
-import MypageSidebar from '@/components/organisms/sidebar/mypageSidebar/MypageSidebar';
-import { useUserStore } from '@/store/userStore';
-import { useEffect, useState } from 'react';
-import { getCurrentUser } from '@/apis/user/getCurrentUser';
-import { getUserById } from '@/apis/user/getUserById';
+import MyPageClient from '@/components/templates/myPage/MyPageClient';
 
 export default function MyPageLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(true);
-  const [profileInfo, setProfileInfo] = useState<{
-    profileImage: string;
-    name: string;
-  } | null>(null);
-  const { member: storeMember, logout } = useUserStore();
-
-  // 사용자 정보 가져오기
-  useEffect(() => {
-    const fetchUserInfo = async () => {
-      try {
-        let memberId;
-
-        if (storeMember && storeMember?.id) {
-          memberId = storeMember.id;
-        } else {
-          // store에 저장된 member의 id가 없는 경우 현재 사용자의 정보를 요청하고 id를 가져옴
-          const userInfo = await getCurrentUser();
-          memberId = userInfo.id;
-
-          if (!userInfo) {
-            await logout();
-            return;
-          }
-        }
-
-        const memberInfo = await getUserById({ userId: memberId });
-
-        // 프로필 정보 설정
-        setProfileInfo({
-          profileImage: memberInfo.profileImage,
-          name: memberInfo.name,
-        });
-      } catch (error) {
-        // API 호출 실패 시 상세 로깅
-        console.error('사용자 정보 조회 실패:', error);
-
-        // 에러 유형에 따른 처리
-        if (error instanceof Error) {
-          console.error(`에러 메시지: ${error.message}`);
-          console.error(`에러 스택: ${error.stack}`);
-        }
-
-        // store 초기화 및 로그인 페이지로 리다이렉트
-        await logout();
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchUserInfo();
-  }, [router, storeMember, logout]);
-
-  // 로딩 중이거나 프로필 정보가 없는 경우 처리
-  if (isLoading || !profileInfo) {
-    return (
-      <ReactQueryClientProvider>
-        <div className="flex items-center justify-center h-screen">
-          <div>로딩 중...</div>
-        </div>
-      </ReactQueryClientProvider>
-    );
-  }
-
   return (
     <ReactQueryClientProvider>
-      <div className="flex gap-36 justify-center my-72">
-        <MypageSidebar profileInfo={profileInfo} />
-        <main className="w-750">{children}</main>
-      </div>
+      <MyPageClient>{children}</MyPageClient>
     </ReactQueryClientProvider>
   );
 }

--- a/src/components/molecules/editableField/EditableField.tsx
+++ b/src/components/molecules/editableField/EditableField.tsx
@@ -45,7 +45,7 @@ export default function EditableField({
             onChange={onChange}
             placeholder={placeholder}
             disabled={disabled || !isEditable}
-            isEditable={id !== 'email' && id !== 'password' && id !== 'phone'}
+            isEditable={id !== 'email' && id !== 'phone'}
             rows={rows}
           />
         ) : (
@@ -56,7 +56,7 @@ export default function EditableField({
             onChange={onChange}
             placeholder={placeholder}
             disabled={disabled || !isEditable}
-            isEditable={id !== 'email' && id !== 'password' && id !== 'phone'}
+            isEditable={id !== 'email' && id !== 'phone'}
           />
         )
       }

--- a/src/components/molecules/passwordInput/PasswordInput.tsx
+++ b/src/components/molecules/passwordInput/PasswordInput.tsx
@@ -22,7 +22,7 @@ function PasswordInput({
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   return (
-    <div className="relative group">
+    <div className="w-full relative group">
       <LabeledInput
         color="transparent"
         errorText={errorText}

--- a/src/components/organisms/userInfoForm/UserInfoForm.tsx
+++ b/src/components/organisms/userInfoForm/UserInfoForm.tsx
@@ -1,9 +1,13 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import EditableField from '@/components/molecules/editableField/EditableField';
 import { useUserStore } from '@/store/userStore';
 import { updateUser } from '@/apis/user/updateUser';
+import { updatePassword, PasswordError } from '@/apis/user/updatePassword';
 import { toast } from 'sonner';
 import { Member } from '@/types/user';
+import StandardButton from '@/components/atoms/buttons/standardButton/StandardButton';
+import PasswordInput from '@/components/molecules/passwordInput/PasswordInput';
+import { FormValidator } from '@/utils/FormValidator';
 
 interface UserInfoFormProps {
   initialData: Member;
@@ -14,7 +18,40 @@ export default function UserInfoForm({ initialData }: UserInfoFormProps) {
   const [name, setName] = useState(initialData.name);
   const [phone, setPhone] = useState(initialData.phone);
   const [isNameEditable, setIsNameEditable] = useState(false);
+  const [isPasswordEditable, setIsPasswordEditable] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+
+  // 유효성 검사 상태
+  const [currentPasswordError, setCurrentPasswordError] = useState('');
+  const [newPasswordError, setNewPasswordError] = useState('');
+  const [isFormValid, setIsFormValid] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+
+  // 비밀번호 유효성 검사
+  useEffect(() => {
+    // 현재 비밀번호는 비어있지 않아야 함
+    if (!currentPassword) {
+      setCurrentPasswordError('');
+    } else {
+      setCurrentPasswordError('');
+    }
+
+    // 새 비밀번호 유효성 검사
+    if (!newPassword) {
+      setNewPasswordError('');
+    } else {
+      const validationResult = FormValidator.validatePassword(newPassword);
+      setNewPasswordError(validationResult.isValid ? '' : validationResult.errorMessage);
+    }
+
+    // 폼 유효성 검사
+    setIsFormValid(currentPassword.length > 0 && newPassword.length > 0 && !newPasswordError);
+
+    // 입력 필드가 변경될 때마다 제출 오류 초기화
+    setSubmitError('');
+  }, [currentPassword, newPassword, newPasswordError]);
 
   const handleNameEditClick = async () => {
     if (isNameEditable) {
@@ -47,6 +84,81 @@ export default function UserInfoForm({ initialData }: UserInfoFormProps) {
     }
   };
 
+  const handlePasswordEditClick = async () => {
+    if (isPasswordEditable) {
+      if (!member?.id) return;
+
+      if (!currentPassword || !newPassword) {
+        setSubmitError('현재 비밀번호와 새 비밀번호를 모두 입력해주세요.');
+        return;
+      }
+
+      if (!isFormValid) {
+        setSubmitError('비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다.');
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        await updatePassword({
+          userId: member.id,
+          currentPassword,
+          newPassword,
+        });
+
+        toast.success('비밀번호가 성공적으로 변경되었습니다.');
+        setCurrentPassword('');
+        setNewPassword('');
+        setIsPasswordEditable(false);
+        setSubmitError('');
+      } catch (error) {
+        // 에러 타입에 따른 처리
+        if (error && typeof error === 'object' && 'code' in error) {
+          const passwordError = error as PasswordError;
+
+          switch (passwordError.code) {
+            case 400:
+              toast.error('요청 데이터의 형식이 올바르지 않습니다.');
+              break;
+            case 401:
+              toast.error('현재 비밀번호가 올바르지 않습니다.');
+              break;
+            case 403:
+              toast.error('로그인이 제한된 계정입니다.');
+              break;
+            case 404:
+              toast.error('사용자 정보를 찾을 수 없습니다.');
+              break;
+            case 429:
+              toast.error('비밀번호 변경 시도 횟수가 초과되었습니다. 잠시 후 다시 시도해주세요.');
+              break;
+            case 500:
+              toast.error('서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+              break;
+            default:
+              toast.error(passwordError.message || '비밀번호 변경에 실패했습니다.');
+          }
+        } else {
+          toast.error('비밀번호 변경에 실패했습니다.');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    } else {
+      setIsPasswordEditable(true);
+      setSubmitError('');
+    }
+  };
+
+  const handlePasswordCancel = () => {
+    setIsPasswordEditable(false);
+    setCurrentPassword('');
+    setNewPassword('');
+    setCurrentPasswordError('');
+    setNewPasswordError('');
+    setSubmitError('');
+  };
+
   return (
     <div className="flex flex-col gap-32">
       <EditableField
@@ -71,16 +183,57 @@ export default function UserInfoForm({ initialData }: UserInfoFormProps) {
         disabled={true}
       />
 
-      <EditableField
-        id="password"
-        label="비밀번호"
-        type="password"
-        value="********"
-        placeholder="********"
-        onChange={() => {}}
-        isEditable={false}
-        disabled={true}
-      />
+      {isPasswordEditable ? (
+        <div className="flex flex-col gap-16 items-end">
+          <hr className="w-full" />
+          <PasswordInput
+            id="currentPassword"
+            label="현재 비밀번호"
+            value={currentPassword}
+            onChange={setCurrentPassword}
+            placeholder="현재 비밀번호를 입력하세요"
+            errorText={currentPasswordError}
+          />
+          <PasswordInput
+            id="newPassword"
+            label="새 비밀번호"
+            value={newPassword}
+            onChange={setNewPassword}
+            placeholder="새 비밀번호를 입력하세요"
+            errorText={newPasswordError}
+          />
+          {submitError && <div className="w-full text-red-500 text-sm mt-2">{submitError}</div>}
+          <div className="flex gap-8">
+            <StandardButton
+              text="취소"
+              onClick={handlePasswordCancel}
+              disabled={isLoading}
+              state="default"
+              size="fit"
+            />
+            <StandardButton
+              text={isLoading ? '처리 중...' : '비밀번호 변경'}
+              onClick={handlePasswordEditClick}
+              disabled={isLoading || !isFormValid}
+              state="dark"
+              size="fit"
+            />
+          </div>
+          <hr className="w-full" />
+        </div>
+      ) : (
+        <EditableField
+          id="password"
+          label="비밀번호"
+          type="password"
+          value="********"
+          placeholder="********"
+          onChange={() => {}}
+          isEditable={false}
+          onEditClick={handlePasswordEditClick}
+          disabled={isLoading}
+        />
+      )}
 
       <EditableField
         id="phone"

--- a/src/components/templates/myPage/MyPageClient.tsx
+++ b/src/components/templates/myPage/MyPageClient.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useUserStore } from '@/store/userStore';
+import { getCurrentUser } from '@/apis/user/getCurrentUser';
+import { getUserById } from '@/apis/user/getUserById';
+import MypageSidebar from '@/components/organisms/sidebar/mypageSidebar/MypageSidebar';
+
+interface MyPageClientProps {
+  children: React.ReactNode;
+}
+
+export default function MyPageClient({ children }: MyPageClientProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [profileInfo, setProfileInfo] = useState<{
+    profileImage: string;
+    name: string;
+  } | null>(null);
+  const { member: storeMember } = useUserStore();
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        let memberId: number;
+
+        if (storeMember?.id) {
+          memberId = storeMember.id;
+        } else {
+          const userInfo = await getCurrentUser();
+          if (!userInfo) {
+            router.push('/');
+            return;
+          }
+          memberId = userInfo.id;
+        }
+
+        const memberInfo = await getUserById({ userId: memberId });
+        setProfileInfo({
+          profileImage: memberInfo.profileImage,
+          name: memberInfo.name,
+        });
+      } catch (error) {
+        console.error('사용자 정보 조회 실패:', error);
+        if (error instanceof Error && error.message.includes('401')) {
+          router.push('/');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUserInfo();
+  }, [router, storeMember]);
+
+  if (isLoading || !profileInfo) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <div>로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-36 justify-center my-72">
+      <MypageSidebar profileInfo={profileInfo} />
+      <main className="w-750">{children}</main>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 PR 타입  
- [x] 기능 추가  
- [ ] 기능 삭제  
- [x] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트  
- [ ] 문서  

## ✅ 반영 브랜치  
- [ ] main  
- [x] merge  

## 🔥 변경사항  
- `MyPageLayout` 내 사용자 정보 로딩 로직을 `MyPageClient`로 이동하여 역할 분리 및 구조 개선  
- 사용자 비밀번호 변경을 위한 API 구현  
- `EditableField` 컴포넌트의 수정 가능 여부 조건 수정  
- `PasswordInput` 컴포넌트 스타일 개선  
- 사용자 정보 폼 내 비밀번호 변경 기능 추가  

## 📸 참고 사진  
![image](https://github.com/user-attachments/assets/9bf6357c-1aab-4155-a100-834f1989dfcf)
